### PR TITLE
Simplify cf target output processing

### DIFF
--- a/bin/cf-deployproxy
+++ b/bin/cf-deployproxy
@@ -41,8 +41,8 @@ fi
 appnames=$1
 
 # Grab the starting space and org where the command was run
-startorg=$(   cf target | grep org:   | cut -d : -f 2 | sed s/\ //g)
-startspace=$( cf target | grep space: | cut -d : -f 2 | sed s/\ //g)
+startorg=$(   cf target | grep org:   | awk --field-separator ' ' '{ print $2 }')
+startspace=$( cf target | grep space: | awk --field-separator ' ' '{ print $2 }')
 
 if [ -z "${appnames}" ]; then
     echo "ERROR: You must supply at least appnames."


### PR DESCRIPTION
Instead of using a combination of sed/cut, using awk to print the second field of the output makes the intent of these lines clearer as well as uses one less pipe to get the job done.