### PR TITLE
bumped caddy from 2.4.6 to 2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # See "Adding custom Caddy modules" here:
 # https://hub.docker.com/_/caddy
 
-FROM caddy:2.4.6-builder AS builder
+FROM caddy:2.5.1-builder AS builder
 
 RUN xcaddy build \
     --with github.com/hairyhenderson/caddy-teapot-module@v0.0.3-0 \
     --with github.com/caddyserver/forwardproxy@caddy2
 
-FROM caddy:2.4.6-alpine
+FROM caddy:2.5.1-alpine
 
 RUN apk update
 RUN apk upgrade


### PR DESCRIPTION
see https://github.com/caddyserver/caddy/releases/tag/v2.5.1. Doesnt seem to impact functionality for the egress proxy, but cant hurt to bump