### PR TITLE
removed awk as not all awks have --field-separator

### DIFF
--- a/bin/cf-deployproxy
+++ b/bin/cf-deployproxy
@@ -41,8 +41,8 @@ fi
 appnames=$1
 
 # Grab the starting space and org where the command was run
-startorg=$(   cf target | grep org:   | awk --field-separator ' ' '{ print $2 }')
-startspace=$( cf target | grep space: | awk --field-separator ' ' '{ print $2 }')
+startorg=$(   cf target | grep org   | tr -s ' ' | cut -d ' ' -f 2 )
+startspace=$( cf target | grep space | tr -s ' ' | cut -d ' ' -f 2 )
 
 if [ -z "${appnames}" ]; then
     echo "ERROR: You must supply at least appnames."


### PR DESCRIPTION
Howdy @mogul , 

We are attempting to put this into a [github action](https://github.com/GSA/data.gov/blob/3549c4d6840b9171e35ae8ce06ab3f80ec61aba6/.github/workflows/enable-egress.yml) and ran into an issue that the version of `awk` that the github action runner has does not have the `--field-separator` flag, so I replaced the parsing (similar to [disable-egress](https://github.com/GSA/data.gov/blob/3549c4d6840b9171e35ae8ce06ab3f80ec61aba6/bin/disable-egress#L33). 