### PR TITLE
Updates to deploy script from Notify use

### DIFF
--- a/bin/cf-deployproxy
+++ b/bin/cf-deployproxy
@@ -6,22 +6,32 @@
 set -e
 set -o pipefail
 
+# Grab the starting space and org where the command was run
+startorg=$(   cf target | grep org   | tr -s ' ' | cut -d ' ' -f 2 )
+startspace=$( cf target | grep space | tr -s ' ' | cut -d ' ' -f 2 )
+egressspace="$startspace-egress"
+egressorg=$startorg
+proxyprefix="proxy-$(echo "$startorg" | tr _. - )-$(echo "$startspace" | tr _. -)"
+envvariablename="https_proxy"
+
 usage="
 $0: (Re-)deploy egress proxies for a set of apps
 
 Usage:
    $0 -h
-   $0 app[,app2,app3...] [ egressspace [egressorg] ]
+   $0 -a app[,app2,app3...] [-s egressspace] [-o egressorg] [-p proxyprefix] [-e envvariablename]
 
 Options:
--h:            show help and exit
-appnames:      comma-separated list of apps that should have egress-proxies
-egressspace:   space with public egress (default: <currentspace>-egress)
-egressorg:     org where the public egress space is (default: <currentorg>)
+-h:                   show help and exit
+-a appnames:          comma-separated list of apps that should have egress-proxies
+-s egressspace:       space with public egress (default: $egressspace)
+-o egressorg:         org where the public egress space is (default: $egressorg)
+-p proxyprefix:       prefix to name the proxy app. (default: $proxyprefix)
+-e envvariablename:   name of variable to set on target apps. (default: $envvariablename)
 
 If the environment variable DRYRUN is set, the planned commands will be echoed rather
 than invoked. For example:
-   DRYRUN=1 $0 app1,app2 somespace someorg
+   DRYRUN=1 $0 -a app1,app2 -s somespace -o someorg
 
 Requirements:
 - You must be a SpaceDeveloper in the current space and the egress_space.
@@ -30,19 +40,36 @@ NOTES:
 - Files <app>.<allow|deny>.acl will be created if they don't exist
 - Any S3 buckets bound to an app will automatically be allowed for that app
 - Your apps will be restarted in a rolling fashion to pick up variable changes
-- Post-restart, just use the http_proxy variable when making egress connections!
+- Post-restart, just use the <envvariablename> variable when making egress connections!
+- You may want to set the <envvariablename> to a different value so that it is not set
+    during staging. If you do this, you must configure your app to use that variable manually
 "
 
-if [[ "$1" == "-h" ]]; then
-    echo "${usage}"
-    exit 1
-fi
+appnames=""
 
-appnames=$1
-
-# Grab the starting space and org where the command was run
-startorg=$(   cf target | grep org   | tr -s ' ' | cut -d ' ' -f 2 )
-startspace=$( cf target | grep space | tr -s ' ' | cut -d ' ' -f 2 )
+while getopts ":ha:s:o:p:e:" opt; do
+    case "$opt" in
+        a)
+            appnames=${OPTARG}
+            ;;
+        s)
+            egressspace=${OPTARG}
+            ;;
+        o)
+            egressorg=${OPTARG}
+            ;;
+        p)
+            proxyprefix=${OPTARG}
+            ;;
+        e)
+            envvariablename=${OPTARG}
+            ;;
+        h)
+            echo "$usage"
+            exit 0
+            ;;
+    esac
+done
 
 if [ -z "${appnames}" ]; then
     echo "ERROR: You must supply at least 1 app name."
@@ -50,8 +77,6 @@ if [ -z "${appnames}" ]; then
     exit 1
 fi
 
-egressspace=${2:-${startspace}-egress}
-egressorg=${3:-$startorg}
 applist="${appnames//,/ }"
 
 # Drop them off where we found them
@@ -109,7 +134,7 @@ for app in $applist ; do
     touch "$app".deny.acl "$app".allow.acl
 
     # Assemble vars.yml file content
-    proxyname="proxy-$(echo "$startorg" | tr _. - )-$(echo "$startspace" | tr _. -)-${app}"
+    proxyname="${proxyprefix}-${app}"
     # A function to generate a random quote-safe password
     randpw(){ < /dev/urandom base64 | tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo; }
 
@@ -142,7 +167,7 @@ $proxyallow
     fi
     $output cf target -o "$startorg" -s "$startspace"
     $output cf add-network-policy "$app" "$proxyname" -s "$egressspace" -o "$egressorg" --protocol tcp --port 8080
-    $output cf set-env "$app" https_proxy "https://$username:$password@$proxyname.apps.internal:8080"
+    $output cf set-env "$app" "$envvariablename" "https://$username:$password@$proxyname.apps.internal:8080"
     $output cf restart "$app" --no-wait --strategy rolling
 
 done

--- a/bin/cf-deployproxy
+++ b/bin/cf-deployproxy
@@ -121,8 +121,8 @@ for app in $applist ; do
     proxyallow=$( cat "$app".allow.acl <(echo "$buckethosts") )
 
     # Normalize into a YAML multiline block form
-    proxydeny=$(  echo "$proxydeny"  | sed 's/^\S/ &/' | sed 's/\ /\n  /g' | sed '/^\s*$/d' )
-    proxyallow=$( echo "$proxyallow" | sed 's/^\S/ &/' | sed 's/\ /\n  /g' | sed '/^\s*$/d' )
+    proxydeny=$(  echo "$proxydeny"  | sed 's/^[^[:space:]]/ &/' | sed 's/\ /\n  /g' | sed '/^\s*$/d' )
+    proxyallow=$( echo "$proxyallow" | sed 's/^[^[:space:]]/ &/' | sed 's/\ /\n  /g' | sed '/^\s*$/d' )
     varsfile="proxyname: $proxyname
 hostname: $proxyname
 username: $username

--- a/bin/cf-deployproxy
+++ b/bin/cf-deployproxy
@@ -97,10 +97,11 @@ for app in $applist ; do
         # Add attached buckets to the allow list
         BUCKET=$(            echo "$VCAP_SERVICES" | jq -r ".s3[$i].credentials.bucket")
         AWS_ENDPOINT=$(      echo "$VCAP_SERVICES" | jq -r ".s3[$i].credentials.endpoint")
+        AWS_ALT_ENDPOINT=$(  echo "$AWS_ENDPOINT" | sed 's/^s3-/s3./')
         AWS_FIPS_ENDPOINT=$( echo "$VCAP_SERVICES" | jq -r ".s3[$i].credentials.fips_endpoint")
 
-        # Add both the FIPS and non-FIPS hostnames
-        buckethosts="$buckethosts ${BUCKET}.${AWS_ENDPOINT} ${BUCKET}.${AWS_FIPS_ENDPOINT}"
+        # Add both the FIPS and non-FIPS hostnames, and the alt format of BUCKET.s3.REGION... that boto3 uses
+        buckethosts="$buckethosts ${BUCKET}.${AWS_ENDPOINT} ${BUCKET}.${AWS_ALT_ENDPOINT} ${BUCKET}.${AWS_FIPS_ENDPOINT}"
         ((i+=1))
     done
 


### PR DESCRIPTION
Adds to the deploy script:

* subdomain format for auto-allowed s3 buckets, because boto3 constructs endpoints that way.
* update the sed usage for processing proxyallow and proxydeny so that it also works on macOS
* More flexibility in passing optional arguments to the script.

The last one is not backwards compatible. Existing script use will need to add flags before each of the arguments they are currently using.